### PR TITLE
Fix autotick bot

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
 {% set component_name = "plugin" %}
 {% set repo_name = "gz-" + component_name %}
-{% set version = "2.0.0" %}
-{% set major_version = version.split('.')[0] %}
+{% set version = "2_2.0.0" %}
+{% set version_package = version.split('_')[1] %}
+{% set major_version = version.split('_')[0] %}
 {% set name = repo_name + major_version %}
 {% set component_version = component_name + major_version %}
 {% set cxx_name = "lib" + name %}
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ version_package }}
 
 source:
-  - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ major_version }}_{{ version }}.tar.gz
+  - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ version }}.tar.gz
     sha256: 4a80ceffcfa41c83f0c39678a84c67a873fcafee16026f7a96d58bb08b25641b
 
 build:


### PR DESCRIPTION
Hopefully fix https://github.com/conda-forge/gz-common-feedstock/issues/10, w.r.t. to https://github.com/conda-forge/gz-sim-feedstock/issues/11 I try to continue to use `{{ repo_name }}` in the url, but w.r.t. to https://github.com/conda-forge/gz-plugin-feedstock/pull/7  `{{ repo_name }}` is assigned to a string literal, it is not the result of the concatenation of different strings.
 
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
